### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/build_emscripten.yml
+++ b/.github/workflows/build_emscripten.yml
@@ -1,0 +1,66 @@
+name: Emscripten
+
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "*"
+
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    name: Build & Test Rust Crate
+    runs-on: ubuntu-latest
+
+    env:
+      RUST_BACKTRACE: full
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup EMSDK
+        uses: mymindstorm/setup-emsdk@v11
+        with:
+          # Make sure to set a version number!
+          version: 3.1.27
+          # This is the name of the cache folder.
+          # The cache folder will be placed in the build directory,
+          #  so make sure it doesn't conflict with anything!
+          actions-cache-folder: "emsdk-cache"
+
+      - name: Verify EMSDK
+        run: emcc -v
+
+      - name: Install Packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dev mesa-common-dev libsdl2-dev libglm-dev
+
+      - name: Update Local Toolchain
+        run: |
+          rustup update
+          rustup component add clippy
+          rustup target add wasm32-unknown-emscripten
+
+      - name: Toolchain Info
+        run: |
+          cargo --version --verbose
+          rustc --version
+          cargo clippy --version
+
+      - name: Lint
+        run: |
+          cargo fmt -- --check
+          # cargo clippy -- -D warnings
+
+      - name: Run Tests
+        run: |
+          cargo check
+          # cargo test --all
+
+      - name: Build Debug
+        run: cargo build --target wasm32-unknown-emscripten

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,0 +1,52 @@
+name: Ubuntu Linux (x86_64)
+
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "*"
+
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    name: Build & Test Rust Crate
+    runs-on: ubuntu-latest
+
+    env:
+      RUST_BACKTRACE: full
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Install Packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dev mesa-common-dev libsdl2-dev libglm-dev
+
+      - name: Update Local Toolchain
+        run: |
+          rustup update
+          rustup component add clippy
+
+      - name: Toolchain Info
+        run: |
+          cargo --version --verbose
+          rustc --version
+          cargo clippy --version
+
+      - name: Lint
+        run: |
+          cargo fmt -- --check
+          # cargo clippy -- -D warnings
+
+      - name: Run Tests
+        run: |
+          cargo check
+          # cargo test --all
+
+      - name: Build Debug
+        run: cargo build

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -1,0 +1,47 @@
+name: macOS (x86_64)
+
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "*"
+
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    name: Build & Test Rust Crate
+    runs-on: macos-latest
+
+    env:
+      RUST_BACKTRACE: full
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update Local Toolchain
+        run: |
+          rustup update
+          rustup component add clippy
+
+      - name: Toolchain Info
+        run: |
+          cargo --version --verbose
+          rustc --version
+          cargo clippy --version
+
+      - name: Lint
+        run: |
+          cargo fmt -- --check
+          # cargo clippy -- -D warnings
+
+      - name: Run Tests
+        run: |
+          cargo check
+          # cargo test --all
+
+      - name: Build Debug
+        run: cargo build

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,51 @@
+name: Windows (x64)
+
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "*"
+
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    name: Build & Test Rust Crate
+    runs-on: windows-latest
+
+    env:
+      RUST_BACKTRACE: full
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Install Dependencies
+        run: vcpkg --triplet=x64-windows-static-md install glew
+        
+      - name: Update Local Toolchain
+        run: |
+          rustup update
+          rustup component add clippy
+
+      - name: Toolchain Info
+        run: |
+          cargo --version --verbose
+          rustc --version
+          cargo clippy --version
+
+      - name: Lint
+        run: |
+          cargo fmt -- --check
+          # cargo clippy -- -D warnings
+
+      - name: Run Tests
+        run: |
+          cargo check
+          # cargo test --all
+
+      - name: Build Debug
+        run: cargo build
+

--- a/.github/workflows/publish_crate.yml
+++ b/.github/workflows/publish_crate.yml
@@ -1,0 +1,48 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - "v*"
+
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dev mesa-common-dev libsdl2-dev libglm-dev
+
+      - name: Update Local Toolchain
+        run: |
+          rustup update
+          rustup component add clippy
+
+      - name: Toolchain Info
+        run: |
+          cargo --version --verbose
+          rustc --version
+          cargo clippy --version
+
+      - name: Lint
+        run: |
+          cargo fmt -- --check
+          # cargo clippy -- -D warnings
+
+      - name: Run Tests
+        run: |
+          cargo check
+          # cargo test --all
+
+      - name: Publish
+        env:
+            CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --token $CARGO_REGISTRY_TOKEN

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 libc = "0.2.139"
-projectm-sys = { version = "1.0.5", features = ["playlist"] }
+projectm-sys = { version = "1.0.6", features = ["playlist"] }
 rand = "0.8.5"
 
 [features]

--- a/src/core.rs
+++ b/src/core.rs
@@ -7,11 +7,9 @@
 //!
 //! # Example
 //!
-//! ```
-//! use projectm_rs::core::*;
-//!
-//! let ProjectMHandle = projectm::create();
-//! ```
+// ! use projectm_rs::core::*;
+// !
+// ! let ProjectMHandle = Projectm::create();
 //!
 
 extern crate libc;
@@ -170,7 +168,7 @@ impl Projectm {
 
     pub fn set_texture_search_paths(
         instance: ProjectMHandle,
-        texture_search_paths: Vec<String>,
+        texture_search_paths: &[String],
         count: usize,
     ) {
         let texture_search_paths_cstr: Vec<_> = texture_search_paths
@@ -346,7 +344,7 @@ impl Projectm {
         pressure: i32,
         touch_type: ProjectMTouchType,
     ) {
-        unsafe { ffi::projectm_touch(instance, x, y, pressure, touch_type) };
+        unsafe { ffi::projectm_touch(instance, x, y, pressure, touch_type.try_into().unwrap()) };
     }
 
     pub fn touch_drag(instance: ProjectMHandle, x: f32, y: f32, pressure: i32) {
@@ -371,19 +369,34 @@ impl Projectm {
 
     pub fn pcm_add_float(instance: ProjectMHandle, samples: Vec<f32>, channels: ProjectMChannels) {
         unsafe {
-            ffi::projectm_pcm_add_float(instance, samples.as_ptr(), samples.len() as u32, channels)
+            ffi::projectm_pcm_add_float(
+                instance,
+                samples.as_ptr(),
+                samples.len() as u32,
+                channels.try_into().unwrap(),
+            )
         }
     }
 
     pub fn pcm_add_int16(instance: ProjectMHandle, samples: Vec<i16>, channels: ProjectMChannels) {
         unsafe {
-            ffi::projectm_pcm_add_int16(instance, samples.as_ptr(), samples.len() as u32, channels)
+            ffi::projectm_pcm_add_int16(
+                instance,
+                samples.as_ptr(),
+                samples.len() as u32,
+                channels.try_into().unwrap(),
+            )
         }
     }
 
     pub fn pcm_add_uint8(instance: ProjectMHandle, samples: Vec<u8>, channels: ProjectMChannels) {
         unsafe {
-            ffi::projectm_pcm_add_uint8(instance, samples.as_ptr(), samples.len() as u32, channels)
+            ffi::projectm_pcm_add_uint8(
+                instance,
+                samples.as_ptr(),
+                samples.len() as u32,
+                channels.try_into().unwrap(),
+            )
         }
     }
 


### PR DESCRIPTION
Added GitHub actions to do the listed tasks:

Check Lint, Unit Tests, and Build the projectm-rs crate
Publish the projectm-rs crate (activated by pushing v* tag syntax or manually if Cargo.toml has been properly incremented in a previous commit)

The new actions run a lint checker which requires that the code be cleaned with "cargo fmt & cargo clippy" BEFORE pushing commit or the action will fail on the linter. This is on purpose to guarantee clean code formatting.

(Linter & Clippy have been disabled until the issues have been resolved)