### PR TITLE
core.rs: fix bugs in `write_debug_image_on_next_frame`

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -420,10 +420,10 @@ impl Projectm {
     // -----------------
 
     pub fn write_debug_image_on_next_frame(instance: ProjectMHandle, output_file: Option<&String>) {
-        let output = if let Some(..) = output_file {
-            std::ptr::null()
+        let output = if let Some(output) = output_file {
+            output.as_ptr() as *mut i8
         } else {
-            output_file.unwrap().as_ptr() as *mut i8
+            std::ptr::null()
         };
 
         unsafe { ffi::projectm_write_debug_image_on_next_frame(instance, output) };

--- a/src/core.rs
+++ b/src/core.rs
@@ -420,12 +420,20 @@ impl Projectm {
     // -----------------
 
     pub fn write_debug_image_on_next_frame(instance: ProjectMHandle, output_file: Option<&String>) {
-        let output = if let Some(output) = output_file {
-            output.as_ptr() as *mut i8
-        } else {
-            std::ptr::null()
-        };
+        // Transform the Rust String into a C String - this is needed due to the
+        // fact that Rust Strings are not null terminated.
+        let path = output_file.map(|p| {
+            CString::new(p.as_str())
+                .expect("Provided output file path could not be converted to a C string")
+        });
 
-        unsafe { ffi::projectm_write_debug_image_on_next_frame(instance, output) };
+        // `path` will be alive until the end of the scope, so we can safely get
+        // a pointer to it.
+        let ptr = path
+            .as_ref()
+            .map(|s| s.as_ptr() as *const i8)
+            .unwrap_or(std::ptr::null());
+
+        unsafe { ffi::projectm_write_debug_image_on_next_frame(instance, ptr) };
     }
 }


### PR DESCRIPTION
Implementation of the `write_debug_image_on_next_frame function` had a logic bug where providing `Some` `output_file` would incorrectly pass null to projectM's corresponding function.

`write_debug_image_on_next_frame` was modified to pass a null-terminated string as an argument to an FFI. Passing a Rust string directly to the FFI caused undefined behavior - FFI function expected a null-terminated string, while Rust strings are not null-terminated by default.