### PR TITLE
Allow passing PCM data as slices instead of Vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "projectm"
-version = "2.0.2"
+version = "3.0.0"
 edition = "2021"
 rust-version = "1.65"
 authors = ["AnomieVision <anomievision@gmail.com.com>", "Mischa Spiegelmock <me@mish.dev>"]
 description = "Bindings for ProjectM"
 license = "	LGPL-3.0-or-later"
-repository = "https://github.com/projectM-visualizer/projectm-rs" #https://github.com/anomievision/projectm-rs
+repository = "https://github.com/projectM-visualizer/projectm-rs"
 keywords = ["visualization", "audio", "sound", "projectm"]
 categories = ["multimedia", "multimedia::video", "multimedia::audio"]
 readme = "README.md"

--- a/src/core.rs
+++ b/src/core.rs
@@ -370,7 +370,7 @@ impl Projectm {
         unsafe { ffi::projectm_pcm_get_max_samples() }
     }
 
-    fn pcm_add_float(instance: ProjectMHandle, samples: Vec<f32>, channels: ProjectMChannels) {
+    fn pcm_add_float(instance: ProjectMHandle, samples: &[f32], channels: ProjectMChannels) {
         assert!(
             samples.len() <= Self::pcm_get_max_samples() as usize,
             "Number of samples is greater than max samples"
@@ -386,7 +386,7 @@ impl Projectm {
         }
     }
 
-    fn pcm_add_int16(instance: ProjectMHandle, samples: Vec<i16>, channels: ProjectMChannels) {
+    fn pcm_add_int16(instance: ProjectMHandle, samples: &[i16], channels: ProjectMChannels) {
         assert!(
             samples.len() <= Self::pcm_get_max_samples() as usize,
             "Number of samples is greater than max samples"
@@ -402,7 +402,7 @@ impl Projectm {
         }
     }
 
-    fn pcm_add_uint8(instance: ProjectMHandle, samples: Vec<u8>, channels: ProjectMChannels) {
+    fn pcm_add_uint8(instance: ProjectMHandle, samples: &[u8], channels: ProjectMChannels) {
         assert!(
             samples.len() <= Self::pcm_get_max_samples() as usize,
             "Number of samples is greater than max samples"
@@ -762,7 +762,7 @@ impl ProjectM {
         Projectm::pcm_get_max_samples()
     }
 
-    pub fn pcm_add_float(&self, samples: Vec<f32>, channels: ProjectMChannels) {
+    pub fn pcm_add_float(&self, samples: &[f32], channels: ProjectMChannels) {
         if let Ok(instance) = self.instance.try_borrow() {
             Projectm::pcm_add_float(*instance, samples, channels);
         } else {
@@ -770,7 +770,7 @@ impl ProjectM {
         }
     }
 
-    pub fn pcm_add_int16(&self, samples: Vec<i16>, channels: ProjectMChannels) {
+    pub fn pcm_add_int16(&self, samples: &[i16], channels: ProjectMChannels) {
         if let Ok(instance) = self.instance.try_borrow() {
             Projectm::pcm_add_int16(*instance, samples, channels);
         } else {
@@ -778,7 +778,7 @@ impl ProjectM {
         }
     }
 
-    pub fn pcm_add_uint8(&self, samples: Vec<u8>, channels: ProjectMChannels) {
+    pub fn pcm_add_uint8(&self, samples: &[u8], channels: ProjectMChannels) {
         if let Ok(instance) = self.instance.try_borrow() {
             Projectm::pcm_add_uint8(*instance, samples, channels);
         } else {

--- a/tests/playlist.rs
+++ b/tests/playlist.rs
@@ -6,7 +6,7 @@ mod playlist {
     #[test]
     fn playlist() {
         let projectm = ProjectM::create();
-        let playlist = Playlist::create(projectm);
+        let playlist = Playlist::create(&projectm);
         assert_eq!(playlist.is_empty(), true);
 
         // add ../presets to playlist


### PR DESCRIPTION
ChatGPT recommended using slices because we can avoid extra allocations and ownership transfer when adding PCM data.

1.	Parameter Type:
	•	Changed the samples parameter from Vec<f32> to &[f32] in both the public and internal methods. This allows you to pass a slice directly without allocating a new Vec.
2.	Ownership:
	•	Since slices are borrowed references, there’s no ownership transfer, which is more efficient.
3.	Usage of as_ptr():
	•	Slices can still provide a raw pointer using .as_ptr(), so the FFI call remains unchanged.


Might be a breaking change though, if we care