### PR TITLE
Sync projectm-rs to latest libprojectM (v4.1.6)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "projectm"
-version = "3.1.2"
+version = "3.1.3"
 edition = "2021"
 rust-version = "1.65"
 authors = ["AnomieVision <anomievision@gmail.com.com>", "Mischa Spiegelmock <me@mish.dev>"]

--- a/projectm-sys/Cargo.toml
+++ b/projectm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "projectm-sys"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 rust-version = "1.65"
 authors = ["AnomieVision <anomievision@gmail.com.com>", "Mischa Spiegelmock <me@mish.dev>"]


### PR DESCRIPTION
Hey folks. First off thanks for all the crazy amount of great work on `projectM`. I'm interested in integrating it into a Rust-oriented project and thought I might make an attempt to update some of the bindings to point to the latest `libprojectM` version.

## Summary
- Update git submodule to the latest `libprojectM` as of today (v.4.1.6)
- Bump the crates for `projectm` and `projectm-sys` by 1 minor version

### Testing
- Built the `projectm-sys/libprojectM` submodule on macOS on my Macbook
- Ran `cargo build` in `projectm-sys/` directory
- Ran `cargo build` in `project-rs` root directory
- Build and ran changes locally in this [frontend-sdl-rust PR](https://github.com/projectM-visualizer/frontend-sdl-rust/pull/16), to ensure the Rust app still runs and builds

### Related PR
- https://github.com/projectM-visualizer/frontend-sdl-rust/pull/16

### Questions
- Wondering if it makes sense to match the crate versions (or at least the v4 major version) to the `libprojectM` version to be consistent and match what versions that the Rust bindings are for?
- I saw that the [projectm-sys](https://github.com/projectM-visualizer/projectm-sys) repo also exists here. Is it safe to assume that we want to update the crate in this repo?